### PR TITLE
피드 조회 기능 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 
 /src/main/resources/application-product.yml
+
+### QUERY DSL
+/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,12 @@ dependencies {
     // https://mvnrepository.com/artifact/commons-io/commons-io
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 
+    // Querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     runtimeOnly 'com.h2database:h2'
@@ -50,6 +56,25 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+}
+
+// QueryDsl 빌드 옵션 (선택)
+// QueryDsl 디렉토리 경로
+def querydslDir = "$buildDir/generated/querydsl"
+
+// 경로 추가 >> QueryDsl 소스 코드 컴파일 시 빌드
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+// 컴파일 설정(AnnotationProcessor가 생성하는 소스코드를 해당 경로로 설정)
+tasks.withType(JavaCompile) {
+    options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+// clean실행 시 마지막 작업으로 디렉토리(QClass) 삭제 >> 충돌 방지
+clean.doLast {
+    file(querydslDir).deleteDir()
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/kr/co/writenow/writenow/common/DateUtil.java
+++ b/src/main/java/kr/co/writenow/writenow/common/DateUtil.java
@@ -1,0 +1,16 @@
+package kr.co.writenow.writenow.common;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.util.ObjectUtils;
+
+public class DateUtil {
+
+  public static String datetimeConvertToString(LocalDateTime dateTime) {
+    if (ObjectUtils.isEmpty(dateTime)) {
+      return "";
+    }
+    return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+  }
+
+}

--- a/src/main/java/kr/co/writenow/writenow/common/DateUtil.java
+++ b/src/main/java/kr/co/writenow/writenow/common/DateUtil.java
@@ -2,15 +2,16 @@ package kr.co.writenow.writenow.common;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 import org.springframework.util.ObjectUtils;
 
 public class DateUtil {
 
-  public static String datetimeConvertToString(LocalDateTime dateTime) {
+  public static Optional<String> datetimeConvertToString(LocalDateTime dateTime) {
     if (ObjectUtils.isEmpty(dateTime)) {
-      return "";
+      return Optional.empty();
     }
-    return dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    return Optional.of(dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
   }
 
 }

--- a/src/main/java/kr/co/writenow/writenow/config/QueryDslConfig.java
+++ b/src/main/java/kr/co/writenow/writenow/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package kr.co.writenow.writenow.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/kr/co/writenow/writenow/config/QueryDslConfig.java
+++ b/src/main/java/kr/co/writenow/writenow/config/QueryDslConfig.java
@@ -1,5 +1,6 @@
 package kr.co.writenow.writenow.config;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,6 @@ public class QueryDslConfig {
 
     @Bean
     public JPAQueryFactory jpaQueryFactory(){
-        return new JPAQueryFactory(entityManager);
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
     }
 }

--- a/src/main/java/kr/co/writenow/writenow/controller/user/UserController.java
+++ b/src/main/java/kr/co/writenow/writenow/controller/user/UserController.java
@@ -1,6 +1,7 @@
 package kr.co.writenow.writenow.controller.user;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import kr.co.writenow.writenow.exception.handler.GlobalExceptionHandler;
 import kr.co.writenow.writenow.service.user.UserService;
 import kr.co.writenow.writenow.service.user.dto.FeedResponse;
@@ -10,7 +11,6 @@ import kr.co.writenow.writenow.service.user.dto.LoginRequest;
 import kr.co.writenow.writenow.service.user.dto.LoginResponse;
 import kr.co.writenow.writenow.service.user.dto.RegisterRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -68,9 +69,10 @@ public class UserController {
   }
 
   @GetMapping("/feed/{userId}")
-  public ResponseEntity<Page<FeedResponse>> fetchFeed(@PathVariable("userId") String userId,
+  public ResponseEntity<List<FeedResponse>> fetchFeed(@PathVariable("userId") String userId,
+      @RequestParam(value = "lastPostNo", required = false) Long lastPostNo,
       @PageableDefault Pageable pageable) {
-    return ResponseEntity.ok(userService.fetchFeed(userId, pageable));
+    return ResponseEntity.ok(userService.fetchFeed(lastPostNo, userId, pageable));
   }
 
 }

--- a/src/main/java/kr/co/writenow/writenow/controller/user/UserController.java
+++ b/src/main/java/kr/co/writenow/writenow/controller/user/UserController.java
@@ -3,54 +3,74 @@ package kr.co.writenow.writenow.controller.user;
 import jakarta.validation.Valid;
 import kr.co.writenow.writenow.exception.handler.GlobalExceptionHandler;
 import kr.co.writenow.writenow.service.user.UserService;
-import kr.co.writenow.writenow.service.user.dto.*;
+import kr.co.writenow.writenow.service.user.dto.FeedResponse;
+import kr.co.writenow.writenow.service.user.dto.FollowRequest;
+import kr.co.writenow.writenow.service.user.dto.FollowResponse;
+import kr.co.writenow.writenow.service.user.dto.LoginRequest;
+import kr.co.writenow.writenow.service.user.dto.LoginResponse;
+import kr.co.writenow.writenow.service.user.dto.RegisterRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user")
 public class UserController {
 
-    private final UserService userService;
+  private final UserService userService;
 
-    @PostMapping("/register")
-    public ResponseEntity<Object> register(@Valid @RequestBody RegisterRequest request,
-        Errors errors) {
-        if (errors.hasErrors()) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(GlobalExceptionHandler.validateErrorsHandler(errors));
-        }
-
-        userService.register(request);
-
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .build();
+  @PostMapping("/register")
+  public ResponseEntity<Object> register(@Valid @RequestBody RegisterRequest request,
+      Errors errors) {
+    if (errors.hasErrors()) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+          .body(GlobalExceptionHandler.validateErrorsHandler(errors));
     }
 
-    @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
-        return ResponseEntity.status(HttpStatus.OK)
-            .body(userService.login(request));
-    }
+    userService.register(request);
 
-    @GetMapping("/logout")
-    public void logout() {
-        userService.logout();
-    }
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .build();
+  }
 
-    @PostMapping("/follow")
-    public ResponseEntity<FollowResponse> follow(@RequestBody FollowRequest request){
-        return ResponseEntity.ok(userService.follow(request));
-    }
+  @PostMapping("/login")
+  public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(userService.login(request));
+  }
 
-    @DeleteMapping("/follow")
-    public void followCancel(@RequestBody FollowRequest request){
-        userService.followCancel(request);
-    }
+  @GetMapping("/logout")
+  public void logout() {
+    userService.logout();
+  }
+
+  @PostMapping("/follow")
+  public ResponseEntity<FollowResponse> follow(@RequestBody FollowRequest request) {
+    return ResponseEntity.ok(userService.follow(request));
+  }
+
+  @DeleteMapping("/follow")
+  public void followCancel(@RequestBody FollowRequest request) {
+    userService.followCancel(request);
+  }
+
+  @GetMapping("/feed/{userId}")
+  public ResponseEntity<Page<FeedResponse>> fetchFeed(@PathVariable("userId") String userId,
+      @PageableDefault Pageable pageable) {
+    return ResponseEntity.ok(userService.fetchFeed(userId, pageable));
+  }
 
 }

--- a/src/main/java/kr/co/writenow/writenow/domain/post/PostImage.java
+++ b/src/main/java/kr/co/writenow/writenow/domain/post/PostImage.java
@@ -3,11 +3,13 @@ package kr.co.writenow.writenow.domain.post;
 import jakarta.persistence.*;
 import kr.co.writenow.writenow.domain.common.BaseEntity;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "POST_IMAGE")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class PostImage extends BaseEntity {
 
     @Id

--- a/src/main/java/kr/co/writenow/writenow/domain/post/PostTag.java
+++ b/src/main/java/kr/co/writenow/writenow/domain/post/PostTag.java
@@ -3,10 +3,11 @@ package kr.co.writenow.writenow.domain.post;
 import jakarta.persistence.*;
 import kr.co.writenow.writenow.domain.tag.Tag;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.Objects;
-
+@Getter
 @Entity
 @Table(name = "POST_TAG")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/kr/co/writenow/writenow/repository/post/PostRepository.java
+++ b/src/main/java/kr/co/writenow/writenow/repository/post/PostRepository.java
@@ -4,4 +4,5 @@ import kr.co.writenow.writenow.domain.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
 }

--- a/src/main/java/kr/co/writenow/writenow/repository/post/PostRepositoryCustom.java
+++ b/src/main/java/kr/co/writenow/writenow/repository/post/PostRepositoryCustom.java
@@ -32,7 +32,7 @@ public class PostRepositoryCustom {
         .leftJoin(postTag).on(post.postNo.eq(postTag.post.postNo))
         .leftJoin(tag).on(postTag.tag.tagNo.eq(tag.tagNo))
         .where(
-            largerThan(lastPostNo),
+            lowerThan(lastPostNo),
             post.writer.userId.eq(userId).or(
             post.writer.userNo.in(
                 JPAExpressions.select(follow.followee.userNo)
@@ -41,7 +41,7 @@ public class PostRepositoryCustom {
             )
         ))
         .limit(pageable.getPageSize())
-        .orderBy(post.createdDatetime.desc())
+        .orderBy(post.postNo.desc())
         .transform(
             groupBy(post.postNo).list(
                 Projections.constructor(FeedProjection.class, post.postNo, post.writer.userId,
@@ -50,7 +50,7 @@ public class PostRepositoryCustom {
         );
   }
 
-  private Predicate largerThan(Long lastPostNo) {
+  private Predicate lowerThan(Long lastPostNo) {
     return lastPostNo != null ? post.postNo.lt(lastPostNo) : null;
   }
 

--- a/src/main/java/kr/co/writenow/writenow/repository/post/PostRepositoryCustom.java
+++ b/src/main/java/kr/co/writenow/writenow/repository/post/PostRepositoryCustom.java
@@ -1,0 +1,58 @@
+package kr.co.writenow.writenow.repository.post;
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.set;
+import static com.querydsl.core.types.Projections.list;
+import static kr.co.writenow.writenow.domain.post.QPost.post;
+import static kr.co.writenow.writenow.domain.post.QPostImage.postImage;
+import static kr.co.writenow.writenow.domain.post.QPostTag.postTag;
+import static kr.co.writenow.writenow.domain.tag.QTag.tag;
+import static kr.co.writenow.writenow.domain.user.QFollow.follow;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import kr.co.writenow.writenow.repository.post.projection.FeedProjection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  public List<FeedProjection> fetchFeed(Long lastPostNo, String userId, Pageable pageable) {
+    return queryFactory
+        .selectFrom(post)
+        .leftJoin(postImage).on(post.postNo.eq(postImage.post.postNo))
+        .leftJoin(postTag).on(post.postNo.eq(postTag.post.postNo))
+        .leftJoin(tag).on(postTag.tag.tagNo.eq(tag.tagNo))
+        .where(
+            largerThan(lastPostNo),
+            post.writer.userId.eq(userId).or(
+            post.writer.userNo.in(
+                JPAExpressions.select(follow.followee.userNo)
+                    .from(follow)
+                    .where(follow.follower.userId.eq(userId))
+            )
+        ))
+        .limit(pageable.getPageSize())
+        .orderBy(post.createdDatetime.desc())
+        .transform(
+            groupBy(post.postNo).list(
+                Projections.constructor(FeedProjection.class, post.postNo, post.writer.userId,
+                    post.writer.nickname, post.content, post.likeCount, post.createdDatetime,
+                    list(postImage.filePath), set(tag.content)))
+        );
+  }
+
+  private Predicate largerThan(Long lastPostNo) {
+    return lastPostNo != null ? post.postNo.lt(lastPostNo) : null;
+  }
+
+}
+

--- a/src/main/java/kr/co/writenow/writenow/repository/post/projection/FeedProjection.java
+++ b/src/main/java/kr/co/writenow/writenow/repository/post/projection/FeedProjection.java
@@ -26,7 +26,9 @@ public class FeedProjection {
     this.userNickname = userNickname;
     this.content = content;
     this.likeCount = likeCount;
-    this.writeDateTime = DateUtil.datetimeConvertToString(writeDateTime);
+    DateUtil.datetimeConvertToString(writeDateTime).ifPresent(datetime-> {
+      this.writeDateTime = datetime;
+    });
     this.imagePaths = imagePaths;
     this.tags = tags;
   }

--- a/src/main/java/kr/co/writenow/writenow/repository/post/projection/FeedProjection.java
+++ b/src/main/java/kr/co/writenow/writenow/repository/post/projection/FeedProjection.java
@@ -1,0 +1,33 @@
+package kr.co.writenow.writenow.repository.post.projection;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import kr.co.writenow.writenow.common.DateUtil;
+import lombok.Getter;
+
+@Getter
+public class FeedProjection {
+
+  private Long postNo;
+  private String userId;
+  private String userNickname;
+  private String content;
+  private Integer likeCount;
+  private String writeDateTime;
+  private List<String> imagePaths;
+  private Set<String> tags;
+
+
+  public FeedProjection(Long postNo, String userId, String userNickname, String content, Integer likeCount,
+      LocalDateTime writeDateTime, List<String> imagePaths, Set<String> tags) {
+    this.postNo = postNo;
+    this.userId = userId;
+    this.userNickname = userNickname;
+    this.content = content;
+    this.likeCount = likeCount;
+    this.writeDateTime = DateUtil.datetimeConvertToString(writeDateTime);
+    this.imagePaths = imagePaths;
+    this.tags = tags;
+  }
+}

--- a/src/main/java/kr/co/writenow/writenow/service/post/PostImageService.java
+++ b/src/main/java/kr/co/writenow/writenow/service/post/PostImageService.java
@@ -1,32 +1,29 @@
 package kr.co.writenow.writenow.service.post;
 
-import kr.co.writenow.writenow.domain.post.Post;
-import kr.co.writenow.writenow.domain.post.PostImage;
-import kr.co.writenow.writenow.repository.post.PostImageRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import kr.co.writenow.writenow.domain.post.Post;
+import kr.co.writenow.writenow.domain.post.PostImage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class PostImageService {
 
-    private final PostImageRepository postImageRepository;
-
-    public List<PostImage> makePostImageList(Post post, List<File> files, String s3FilePath){
-        if(files.isEmpty()){
-            return Collections.emptyList();
-        }
-        List<PostImage> postImages = new ArrayList<>();
-        for (File file : files) {
-            postImages.add(new PostImage(post, file.getName(), s3FilePath));
-        }
-        return postImages;
+  public List<PostImage> makePostImageList(Post post, List<File> files, String s3FilePath) {
+    if (files.isEmpty()) {
+      return Collections.emptyList();
     }
+    List<PostImage> postImages = new ArrayList<>();
+    for (File file : files) {
+      postImages.add(
+          new PostImage(post, file.getName(), String.join("/", s3FilePath, file.getName())));
+    }
+    return postImages;
+  }
 }

--- a/src/main/java/kr/co/writenow/writenow/service/post/PostService.java
+++ b/src/main/java/kr/co/writenow/writenow/service/post/PostService.java
@@ -1,6 +1,10 @@
 package kr.co.writenow.writenow.service.post;
 
 import jakarta.validation.Valid;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import kr.co.writenow.writenow.common.file.FileService;
 import kr.co.writenow.writenow.common.file.FileUtil;
 import kr.co.writenow.writenow.domain.post.Post;
@@ -15,11 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/kr/co/writenow/writenow/service/post/PostTagService.java
+++ b/src/main/java/kr/co/writenow/writenow/service/post/PostTagService.java
@@ -1,16 +1,18 @@
 package kr.co.writenow.writenow.service.post;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import kr.co.writenow.writenow.domain.post.Post;
 import kr.co.writenow.writenow.domain.post.PostTag;
 import kr.co.writenow.writenow.domain.tag.Tag;
-import kr.co.writenow.writenow.repository.post.PostTagRepository;
 import kr.co.writenow.writenow.repository.tag.TagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
-
-import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -18,7 +20,6 @@ import java.util.*;
 public class PostTagService {
 
     private final TagRepository tagRepository;
-    private final PostTagRepository postTagRepository;
 
     public Set<PostTag> makePostTagSet(Post post, List<String> tagValues){
         if(ObjectUtils.isEmpty(tagValues)){

--- a/src/main/java/kr/co/writenow/writenow/service/user/UserService.java
+++ b/src/main/java/kr/co/writenow/writenow/service/user/UserService.java
@@ -1,5 +1,10 @@
 package kr.co.writenow.writenow.service.user;
 
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import kr.co.writenow.writenow.config.security.jwt.JwtTokenProvider;
 import kr.co.writenow.writenow.domain.user.Follow;
 import kr.co.writenow.writenow.domain.user.Role;
@@ -8,22 +13,31 @@ import kr.co.writenow.writenow.exception.CustomException;
 import kr.co.writenow.writenow.exception.user.InvalidUserException;
 import kr.co.writenow.writenow.exception.user.UserNotFoundException;
 import kr.co.writenow.writenow.exception.user.UserRegisterException;
+import kr.co.writenow.writenow.repository.post.PostRepositoryCustom;
+import kr.co.writenow.writenow.repository.post.projection.FeedProjection;
 import kr.co.writenow.writenow.repository.user.FollowRepository;
 import kr.co.writenow.writenow.repository.user.UserRepository;
-import kr.co.writenow.writenow.service.user.dto.*;
+import kr.co.writenow.writenow.service.user.dto.FeedResponse;
+import kr.co.writenow.writenow.service.user.dto.FollowRequest;
+import kr.co.writenow.writenow.service.user.dto.FollowResponse;
+import kr.co.writenow.writenow.service.user.dto.LoginRequest;
+import kr.co.writenow.writenow.service.user.dto.LoginResponse;
+import kr.co.writenow.writenow.service.user.dto.RegisterRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.authentication.*;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Duration;
-import java.util.Collections;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,125 +45,131 @@ import java.util.Optional;
 @Slf4j
 public class UserService {
 
-    private final PasswordEncoder passwordEncoder;
-    private final UserRepository userRepository;
-    private final AuthenticationManager authenticationManager;
-    private final JwtTokenProvider tokenProvider;
-    private final FollowRepository followRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final UserRepository userRepository;
+  private final AuthenticationManager authenticationManager;
+  private final JwtTokenProvider tokenProvider;
+  private final FollowRepository followRepository;
+  private final PostRepositoryCustom postRepositoryCustom;
 
-    /**
-     * @param request email, nickname, userId, password, gender
-     * @return new user
-     */
-    public void register(RegisterRequest request) {
+  /**
+   * @param request email, nickname, userId, password, gender
+   * @return new user
+   */
+  public void register(RegisterRequest request) {
 
-        this.validate(request);
+    this.validate(request);
 
-        String encodedPassword = passwordEncoder.encode(request.getPassword());
+    String encodedPassword = passwordEncoder.encode(request.getPassword());
 
-        User user = User.builder()
-                .email(request.getEmail())
-                .nickname(request.getNickname())
-                .userId(request.getUserId())
-                .password(encodedPassword)
-                .gender(request.getGender())
-                .isLocked(false)
-                .loginFailCount(0)
-                .roles(Collections.singleton(new Role()))
-                .build();
+    User user = User.builder()
+        .email(request.getEmail())
+        .nickname(request.getNickname())
+        .userId(request.getUserId())
+        .password(encodedPassword)
+        .gender(request.getGender())
+        .isLocked(false)
+        .loginFailCount(0)
+        .roles(Collections.singleton(new Role()))
+        .build();
 
-        userRepository.save(user);
+    userRepository.save(user);
+  }
+
+  private void validate(RegisterRequest request) {
+    Optional<User> byEmail = userRepository.findByEmail(request.getEmail());
+
+    if (byEmail.isPresent()) {
+      throw new UserRegisterException(HttpStatus.BAD_REQUEST, "중복되는 이메일입니다.");
     }
 
-    private void validate(RegisterRequest request) {
-        Optional<User> byEmail = userRepository.findByEmail(request.getEmail());
+    Optional<User> byNickName = userRepository.findByNickname(request.getNickname());
 
-        if (byEmail.isPresent()) {
-            throw new UserRegisterException(HttpStatus.BAD_REQUEST, "중복되는 이메일입니다.");
-        }
-
-        Optional<User> byNickName = userRepository.findByNickname(request.getNickname());
-
-        if (byNickName.isPresent()) {
-            throw new UserRegisterException(HttpStatus.BAD_REQUEST, "중복되는 닉네임입니다.");
-        }
-
-        Optional<User> byUserId = userRepository.findByUserId(request.getUserId());
-
-        if (byUserId.isPresent()) {
-            throw new UserRegisterException(HttpStatus.BAD_REQUEST, "중복되는 아이디입니다.");
-        }
+    if (byNickName.isPresent()) {
+      throw new UserRegisterException(HttpStatus.BAD_REQUEST, "중복되는 닉네임입니다.");
     }
 
-    public LoginResponse login(LoginRequest request) {
-        Authentication authenticate = authenticate(request.userId(), request.password());
-        User user = (User) authenticate.getPrincipal();
-        String token = tokenProvider.generatedToken(user, Duration.ofDays(15));
-        return new LoginResponse(user.getUserId(), user.getNickname(), user.getEmail(), token);
+    Optional<User> byUserId = userRepository.findByUserId(request.getUserId());
+
+    if (byUserId.isPresent()) {
+      throw new UserRegisterException(HttpStatus.BAD_REQUEST, "중복되는 아이디입니다.");
+    }
+  }
+
+  public LoginResponse login(LoginRequest request) {
+    Authentication authenticate = authenticate(request.userId(), request.password());
+    User user = (User) authenticate.getPrincipal();
+    String token = tokenProvider.generatedToken(user, Duration.ofDays(15));
+    return new LoginResponse(user.getUserId(), user.getNickname(), user.getEmail(), token);
+  }
+
+  public Authentication authenticate(String userId, String password) {
+    try {
+      return authenticationManager.authenticate(
+          new UsernamePasswordAuthenticationToken(userId, password));
+    } catch (InternalAuthenticationServiceException e) {
+      throw new UserNotFoundException(HttpStatus.BAD_REQUEST, "아이디와 일치하는 회원이 없습니다.");
+    } catch (DisabledException e) {
+      throw new InvalidUserException(HttpStatus.BAD_REQUEST, "로그인 가능한 회원이 아닙니다.");
+    } catch (BadCredentialsException e) {
+      this.increaseLoginFailCount(userId);
+      throw new BadCredentialsException("비밀번호가 틀렸습니다.");
+    } catch (LockedException e) {
+      throw new LockedException("계정이 잠겨있습니다. 비밀번호 찾기를 진행해주세요.");
+    }
+  }
+
+  public void increaseLoginFailCount(String userId) {
+    Optional<User> byUserId = userRepository.findByUserId(userId);
+    if (byUserId.isEmpty()) {
+      return;
     }
 
-    public Authentication authenticate(String userId, String password) {
-        try {
-            return authenticationManager.authenticate(
-                    new UsernamePasswordAuthenticationToken(userId, password));
-        } catch (InternalAuthenticationServiceException e) {
-            throw new UserNotFoundException(HttpStatus.BAD_REQUEST, "아이디와 일치하는 회원이 없습니다.");
-        } catch (DisabledException e) {
-            throw new InvalidUserException(HttpStatus.BAD_REQUEST, "로그인 가능한 회원이 아닙니다.");
-        } catch (BadCredentialsException e) {
-            this.increaseLoginFailCount(userId);
-            throw new BadCredentialsException("비밀번호가 틀렸습니다.");
-        } catch (LockedException e) {
-            throw new LockedException("계정이 잠겨있습니다. 비밀번호 찾기를 진행해주세요.");
-        }
+    User user = byUserId.get();
+
+    if (user.isMaxLoginFailCount()) {
+      userRepository.locked(user.getUserNo());
+      return;
     }
 
-    public void increaseLoginFailCount(String userId) {
-        Optional<User> byUserId = userRepository.findByUserId(userId);
-        if (byUserId.isEmpty()) {
-            return;
-        }
+    userRepository.increaseLoginFailCount(user.getUserNo());
+  }
 
-        User user = byUserId.get();
+  public void logout() {
+    SecurityContextHolder.clearContext();
+  }
 
-        if (user.isMaxLoginFailCount()) {
-            userRepository.locked(user.getUserNo());
-            return;
-        }
+  public User fetchUserByUserId(String userId) {
+    return userRepository.findByUserId(userId).orElseThrow(() -> {
+      log.warn("{} 아이디로 조회된 회원정보가 없습니다.", userId);
+      return new UserNotFoundException(HttpStatus.BAD_REQUEST, "회원정보가 올바르지 않습니다.");
+    });
+  }
 
-        userRepository.increaseLoginFailCount(user.getUserNo());
+  public FollowResponse follow(FollowRequest request) {
+    User follower = fetchUserByUserId(request.followerUserId());
+    User followee = fetchUserByUserId(request.followeeUserId());
+
+    Optional<Follow> maybeFollow = followRepository.findByFollowerAndFollowee(follower, followee);
+    if (maybeFollow.isPresent()) {
+      throw new CustomException(HttpStatus.BAD_REQUEST, "이미 팔로우 하고 있는 회원입니다.");
     }
 
-    public void logout() {
-        SecurityContextHolder.clearContext();
-    }
+    Follow follow = new Follow(follower, followee);
+    follow = followRepository.save(follow);
 
-    public User fetchUserByUserId(String userId) {
-        return userRepository.findByUserId(userId).orElseThrow(() -> {
-            log.warn("{} 아이디로 조회된 회원정보가 없습니다.", userId);
-            return new UserNotFoundException(HttpStatus.BAD_REQUEST, "회원정보가 올바르지 않습니다.");
-        });
-    }
+    return new FollowResponse(follow.getFollower().getUserId(), follow.getFollowee().getUserId());
+  }
 
-    public FollowResponse follow(FollowRequest request) {
-        User follower = fetchUserByUserId(request.followerUserId());
-        User followee = fetchUserByUserId(request.followeeUserId());
+  public void followCancel(FollowRequest request) {
+    User follower = fetchUserByUserId(request.followerUserId());
+    User followee = fetchUserByUserId(request.followeeUserId());
+    followRepository.deleteByFollowerAndFollowee(follower, followee);
+  }
 
-
-        Optional<Follow> maybeFollow = followRepository.findByFollowerAndFollowee(follower, followee);
-        if(maybeFollow.isPresent()){
-            throw new CustomException(HttpStatus.BAD_REQUEST, "이미 팔로우 하고 있는 회원입니다.");
-        }
-
-        Follow follow = new Follow(follower, followee);
-        follow = followRepository.save(follow);
-
-        return new FollowResponse(follow.getFollower().getUserId(), follow.getFollowee().getUserId());
-    }
-
-    public void followCancel(FollowRequest request) {
-        User follower = fetchUserByUserId(request.followerUserId());
-        User followee = fetchUserByUserId(request.followeeUserId());
-        followRepository.deleteByFollowerAndFollowee(follower, followee);
-    }
+  public List<FeedResponse> fetchFeed(Long lastPostNo, String userId, Pageable pageable) {
+    List<FeedProjection> queryResults = postRepositoryCustom.fetchFeed(lastPostNo, userId,
+        pageable);
+    return queryResults.stream().map(FeedResponse::new).collect(Collectors.toList());
+  }
 }

--- a/src/main/java/kr/co/writenow/writenow/service/user/dto/FeedResponse.java
+++ b/src/main/java/kr/co/writenow/writenow/service/user/dto/FeedResponse.java
@@ -1,0 +1,34 @@
+package kr.co.writenow.writenow.service.user.dto;
+
+import java.util.List;
+import java.util.Set;
+import kr.co.writenow.writenow.repository.post.projection.FeedProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FeedResponse {
+
+  private Long postNo;
+  private String userId;
+  private String userNickname;
+  private String content;
+  private Integer likeCount;
+  private String writeDateTime;
+  private List<String> imagePath;
+  private Set<String> tags;
+
+  public FeedResponse(FeedProjection projection) {
+    this.postNo = projection.getPostNo();
+    this.userId = projection.getUserId();
+    this.userNickname = projection.getUserNickname();
+    this.content = projection.getContent();
+    this.likeCount = projection.getLikeCount();
+    this.writeDateTime = projection.getWriteDateTime();
+    this.imagePath = projection.getImagePaths();
+    this.tags = projection.getTags();
+  }
+}

--- a/src/test/java/kr/co/writenow/writenow/post/PostServiceTest.java
+++ b/src/test/java/kr/co/writenow/writenow/post/PostServiceTest.java
@@ -28,10 +28,9 @@ public class PostServiceTest {
 
     @Test
     void manytomanyTest(){
-        //postRepository.save(new Post());
-        Optional<Post> post = postRepository.findById(1L);
-        if(post.isPresent()){
-            List<LikePost> likePosts = post.get().getLikePosts();
-        }
+        Optional<Post> maybePost = postRepository.findById(1L);
+        maybePost.ifPresent(post-> {
+            List<LikePost> likePosts = post.getLikePosts();
+        });
     }
 }

--- a/src/test/java/kr/co/writenow/writenow/post/PostServiceTest.java
+++ b/src/test/java/kr/co/writenow/writenow/post/PostServiceTest.java
@@ -1,0 +1,37 @@
+package kr.co.writenow.writenow.post;
+
+import jakarta.transaction.Transactional;
+import kr.co.writenow.writenow.domain.post.LikePost;
+import kr.co.writenow.writenow.domain.post.Post;
+import kr.co.writenow.writenow.repository.post.PostRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.TestPropertySources;
+
+import java.util.List;
+import java.util.Optional;
+
+@SpringBootTest
+@TestPropertySources(value = {@TestPropertySource("classpath:application.yml")})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+// 내장 데이터베이스를 쓰지 않기 위한 설정
+@Transactional
+@ContextConfiguration
+public class PostServiceTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Test
+    void manytomanyTest(){
+        //postRepository.save(new Post());
+        Optional<Post> post = postRepository.findById(1L);
+        if(post.isPresent()){
+            List<LikePost> likePosts = post.get().getLikePosts();
+        }
+    }
+}


### PR DESCRIPTION
## 요약
피드 조회 기능을 추가했습니다.

## 주요 변경사항
- querydsl 관련 설정 추가
- 피드 조회 로직 개발
  - 내가 쓴 글, 팔로우 하고 있는 글이 size에 맞게 조회
  - offset을 이용한 쿼리 개발 시 성능이 떨어지기 때문에 조회할 때 이전 조회의 마지막 글 번호(post 엔티티의 PK)를 같이 넘기고 해당 글 번호 미만의 글을 조회하도록 쿼리 작성(미만으로 하는 이유는 정렬이 역순이기 때문에)

## 리뷰 필요부분

현재 SNS 서비스는 피드 조회 시 전체 갯수는 필요치 않아 페이징 처리는 하지 않았지만, 일반적인 서비스에서는 쿼리에 따른 전체 요소의 갯수가 필요할 것 같습니다. 그런데 querydsl의 transform을 사용하게 되면 반환 값이 List로만 가능하고 transform을 사용하지 않더라도 fetchResult를 사용하면 성능이 떨어지는 문제가 있습니다.

찾아봤을 때는 count 쿼리를 따로 날려서 결과적으로 2번 쿼리를 날리는 방식이 있었는데 이 방식보다 나은 방법이 없을 지, 대용량 트래픽 관점에서 페이징 처리는 어떤 식으로 하는지 궁금합니다!