### PR TITLE
글 작성 시 피드 발행 로직을 비동기 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,12 +36,18 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.13'
 
     // https://mvnrepository.com/artifact/commons-io/commons-io
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+
+    implementation 'org.springframework.boot:spring-boot-starter-artemis'
+    implementation 'org.springframework.boot:spring-boot-starter-json'
+    runtimeOnly 'org.apache.activemq:artemis-jakarta-server'
+
 
     // Querydsl 추가
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/kr/co/writenow/writenow/common/event_driven/JmsSendService.java
+++ b/src/main/java/kr/co/writenow/writenow/common/event_driven/JmsSendService.java
@@ -1,0 +1,5 @@
+package kr.co.writenow.writenow.common.event_driven;
+
+public class JmsSendService {
+
+}

--- a/src/main/java/kr/co/writenow/writenow/common/event_driven/SendService.java
+++ b/src/main/java/kr/co/writenow/writenow/common/event_driven/SendService.java
@@ -1,0 +1,7 @@
+package kr.co.writenow.writenow.common.event_driven;
+
+public interface SendService {
+
+  void send(Object arg);
+
+}

--- a/src/main/java/kr/co/writenow/writenow/common/file/FileUtil.java
+++ b/src/main/java/kr/co/writenow/writenow/common/file/FileUtil.java
@@ -1,5 +1,6 @@
 package kr.co.writenow.writenow.common.file;
 
+import java.nio.file.Files;
 import kr.co.writenow.writenow.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,9 +39,10 @@ public class FileUtil {
     }
 
     public static void delete(File file){
-        boolean isDeleted = file.delete();
-        if(isDeleted){
-            log.warn("filePath: {} , 파일이 정상적으로 삭제되지 않았습니다.", file.getAbsoluteFile());
+        try {
+            Files.delete(file.toPath());
+        }catch (IOException e){
+            log.warn("filePath: {}, message: {}, 파일이 정상적으로 삭제되지 않았습니다.", file.getAbsoluteFile(), e.getMessage());
         }
     }
 

--- a/src/main/java/kr/co/writenow/writenow/config/AsyncConfig.java
+++ b/src/main/java/kr/co/writenow/writenow/config/AsyncConfig.java
@@ -1,22 +1,40 @@
 package kr.co.writenow.writenow.config;
 
-import org.springframework.context.annotation.Bean;
+import java.util.concurrent.Executor;
+import kr.co.writenow.writenow.exception.handler.CustomThreadExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
 
-  @Bean
-  public TaskExecutor taskExecutor(){
+  @Value("${threadPool.core-size}")
+  private int coreSize;
+
+  @Value("${threadPool.max-size}")
+  private int maxSize;
+
+  @Value("${threadPool.queue-size}")
+  private int queueSize;
+
+  @Override
+  public Executor getAsyncExecutor() {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(5);
-    executor.setMaxPoolSize(100);
-    executor.setQueueCapacity(50);
+    executor.setCorePoolSize(coreSize);
+    executor.setMaxPoolSize(maxSize);
+    executor.setQueueCapacity(queueSize);
     executor.initialize();
     return executor;
   }
+
+  @Override
+  public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+    return new CustomThreadExceptionHandler();
+  }
+
 }

--- a/src/main/java/kr/co/writenow/writenow/config/AsyncConfig.java
+++ b/src/main/java/kr/co/writenow/writenow/config/AsyncConfig.java
@@ -1,0 +1,22 @@
+package kr.co.writenow.writenow.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+  @Bean
+  public TaskExecutor taskExecutor(){
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(5);
+    executor.setMaxPoolSize(100);
+    executor.setQueueCapacity(50);
+    executor.initialize();
+    return executor;
+  }
+}

--- a/src/main/java/kr/co/writenow/writenow/config/JmsConfig.java
+++ b/src/main/java/kr/co/writenow/writenow/config/JmsConfig.java
@@ -1,0 +1,36 @@
+package kr.co.writenow.writenow.config;
+
+import jakarta.jms.ConnectionFactory;
+import org.springframework.boot.autoconfigure.jms.DefaultJmsListenerContainerFactoryConfigurer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.jms.config.JmsListenerContainerFactory;
+import org.springframework.jms.support.converter.MappingJackson2MessageConverter;
+import org.springframework.jms.support.converter.MessageConverter;
+import org.springframework.jms.support.converter.MessageType;
+
+@Configuration
+@EnableJms
+public class JmsConfig {
+
+  @Bean
+  public JmsListenerContainerFactory<?> myFactory(ConnectionFactory connectionFactory,
+      DefaultJmsListenerContainerFactoryConfigurer configurer) {
+    DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
+
+    configurer.configure(factory, connectionFactory);
+
+    return factory;
+  }
+
+  @Bean
+  public MessageConverter jacksonJmsMessageConverter() {
+    MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+    converter.setTargetType(MessageType.TEXT);
+    converter.setTypeIdPropertyName("_type");
+    return converter;
+  }
+
+}

--- a/src/main/java/kr/co/writenow/writenow/controller/feed/FeedController.java
+++ b/src/main/java/kr/co/writenow/writenow/controller/feed/FeedController.java
@@ -1,0 +1,30 @@
+package kr.co.writenow.writenow.controller.feed;
+
+import java.util.List;
+import kr.co.writenow.writenow.service.feed.FeedService;
+import kr.co.writenow.writenow.service.user.dto.FeedResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/feed")
+@RequiredArgsConstructor
+public class FeedController {
+
+  private final FeedService feedService;
+
+  @GetMapping("/{userId}")
+  public ResponseEntity<List<FeedResponse>> fetchFeed(@PathVariable("userId") String userId,
+      @RequestParam(value = "lastFeedNo", required = false) Long lastFeedNo,
+      @PageableDefault Pageable pageable) {
+    return ResponseEntity.ok(feedService.fetchFeed(lastFeedNo, userId, pageable));
+  }
+
+}

--- a/src/main/java/kr/co/writenow/writenow/controller/user/UserController.java
+++ b/src/main/java/kr/co/writenow/writenow/controller/user/UserController.java
@@ -1,28 +1,22 @@
 package kr.co.writenow.writenow.controller.user;
 
 import jakarta.validation.Valid;
-import java.util.List;
 import kr.co.writenow.writenow.exception.handler.GlobalExceptionHandler;
 import kr.co.writenow.writenow.service.user.UserService;
-import kr.co.writenow.writenow.service.user.dto.FeedResponse;
 import kr.co.writenow.writenow.service.user.dto.FollowRequest;
 import kr.co.writenow.writenow.service.user.dto.FollowResponse;
 import kr.co.writenow.writenow.service.user.dto.LoginRequest;
 import kr.co.writenow.writenow.service.user.dto.LoginResponse;
 import kr.co.writenow.writenow.service.user.dto.RegisterRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -66,13 +60,6 @@ public class UserController {
   @DeleteMapping("/follow")
   public void followCancel(@RequestBody FollowRequest request) {
     userService.followCancel(request);
-  }
-
-  @GetMapping("/feed/{userId}")
-  public ResponseEntity<List<FeedResponse>> fetchFeed(@PathVariable("userId") String userId,
-      @RequestParam(value = "lastFeedNo", required = false) Long lastFeedNo,
-      @PageableDefault Pageable pageable) {
-    return ResponseEntity.ok(userService.fetchFeed(lastFeedNo, userId, pageable));
   }
 
 }

--- a/src/main/java/kr/co/writenow/writenow/controller/user/UserController.java
+++ b/src/main/java/kr/co/writenow/writenow/controller/user/UserController.java
@@ -70,9 +70,9 @@ public class UserController {
 
   @GetMapping("/feed/{userId}")
   public ResponseEntity<List<FeedResponse>> fetchFeed(@PathVariable("userId") String userId,
-      @RequestParam(value = "lastPostNo", required = false) Long lastPostNo,
+      @RequestParam(value = "lastFeedNo", required = false) Long lastFeedNo,
       @PageableDefault Pageable pageable) {
-    return ResponseEntity.ok(userService.fetchFeed(lastPostNo, userId, pageable));
+    return ResponseEntity.ok(userService.fetchFeed(lastFeedNo, userId, pageable));
   }
 
 }

--- a/src/main/java/kr/co/writenow/writenow/domain/feed/Feed.java
+++ b/src/main/java/kr/co/writenow/writenow/domain/feed/Feed.java
@@ -22,6 +22,7 @@ public class Feed extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "FEED_NO")
   private Long feedNo;
 
   @Column(name = "FEED_USER_NO")

--- a/src/main/java/kr/co/writenow/writenow/domain/feed/Feed.java
+++ b/src/main/java/kr/co/writenow/writenow/domain/feed/Feed.java
@@ -5,11 +5,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import kr.co.writenow.writenow.common.DateUtil;
 import kr.co.writenow.writenow.domain.common.BaseEntity;
 import kr.co.writenow.writenow.domain.post.Post;
-import kr.co.writenow.writenow.domain.user.User;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,34 +28,13 @@ public class Feed extends BaseEntity {
   @Column(name = "FEED_USER_NO")
   private Long feedUserNo;
 
-  @Column(name = "POST_NO")
-  private Long postNo;
+  @ManyToOne
+  @JoinColumn(name = "POST_NO")
+  private Post post;
 
-  @Column(name = "WRITER_ID")
-  private String writerId;
-
-  @Column(name = "WRITER_NICKNAME")
-  private String writerNickname;
-
-  @Column(name = "CONTENT")
-  private String content;
-
-  @Column(name = "LIKE_COUNT")
-  private Integer likeCount;
-
-  @Column(name = "WRITE_DATETIME")
-  private String writeDateTime;
-
-  public Feed(Long feedUserNo, Post post, User writer) {
+  public Feed(Long feedUserNo, Post post) {
     this.feedUserNo = feedUserNo;
-    this.postNo = post.getPostNo();
-    this.writerId = writer.getUserId();
-    this.writerNickname = writer.getNickname();
-    this.content = post.getContent();
-    this.likeCount = post.getLikeCount();
-    DateUtil.datetimeConvertToString(post.getCreatedDatetime()).ifPresent(datetime -> {
-      this.writeDateTime = datetime;
-    });
+    this.post = post;
   }
 
 }

--- a/src/main/java/kr/co/writenow/writenow/exception/handler/CustomThreadExceptionHandler.java
+++ b/src/main/java/kr/co/writenow/writenow/exception/handler/CustomThreadExceptionHandler.java
@@ -1,0 +1,14 @@
+package kr.co.writenow.writenow.exception.handler;
+
+import java.lang.reflect.Method;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+@Slf4j
+public class CustomThreadExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        log.error(method + "의 스레드에서 예외 발생", ex);
+    }
+}

--- a/src/main/java/kr/co/writenow/writenow/repository/feed/FeedRepositoryCustom.java
+++ b/src/main/java/kr/co/writenow/writenow/repository/feed/FeedRepositoryCustom.java
@@ -1,0 +1,39 @@
+package kr.co.writenow.writenow.repository.feed;
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+import static com.querydsl.core.group.GroupBy.set;
+import static kr.co.writenow.writenow.domain.feed.QFeed.feed;
+import static kr.co.writenow.writenow.domain.tag.QTag.tag;
+import static kr.co.writenow.writenow.domain.post.QPostImage.postImage;
+import static kr.co.writenow.writenow.domain.post.QPostTag.postTag;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+
+import kr.co.writenow.writenow.repository.post.projection.FeedProjection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FeedRepositoryCustom {
+
+    private final JPAQueryFactory factory;
+
+    public List<FeedProjection> fetchByUserNo(Long userNo, Long lastFeedNo, int pageSize) {
+        return factory.from(feed)
+            .select(Projections.constructor(FeedProjection.class, feed.feedNo, feed.postNo, feed.writerId,
+                feed.writerNickname, feed.content, feed.likeCount, feed.writeDateTime))
+            .where(feed.feedUserNo.eq(userNo), lowerThan(lastFeedNo))
+            .limit(pageSize)
+            .orderBy(feed.feedNo.desc())
+            .fetch();
+    }
+
+    private BooleanExpression lowerThan(Long feedNo) {
+        return feedNo != null ? feed.feedNo.lt(feedNo) : null;
+    }
+}

--- a/src/main/java/kr/co/writenow/writenow/repository/feed/FeedRepositoryCustom.java
+++ b/src/main/java/kr/co/writenow/writenow/repository/feed/FeedRepositoryCustom.java
@@ -1,18 +1,16 @@
 package kr.co.writenow.writenow.repository.feed;
 
-import static com.querydsl.core.group.GroupBy.groupBy;
-import static com.querydsl.core.group.GroupBy.list;
-import static com.querydsl.core.group.GroupBy.set;
 import static kr.co.writenow.writenow.domain.feed.QFeed.feed;
-import static kr.co.writenow.writenow.domain.tag.QTag.tag;
 import static kr.co.writenow.writenow.domain.post.QPostImage.postImage;
 import static kr.co.writenow.writenow.domain.post.QPostTag.postTag;
+import static kr.co.writenow.writenow.domain.tag.QTag.tag;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
-
 import kr.co.writenow.writenow.repository.post.projection.FeedProjection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -21,19 +19,36 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class FeedRepositoryCustom {
 
-    private final JPAQueryFactory factory;
+  private final JPAQueryFactory factory;
 
-    public List<FeedProjection> fetchByUserNo(Long userNo, Long lastFeedNo, int pageSize) {
-        return factory.from(feed)
-            .select(Projections.constructor(FeedProjection.class, feed.feedNo, feed.postNo, feed.writerId,
-                feed.writerNickname, feed.content, feed.likeCount, feed.writeDateTime))
-            .where(feed.feedUserNo.eq(userNo), lowerThan(lastFeedNo))
-            .limit(pageSize)
-            .orderBy(feed.feedNo.desc())
-            .fetch();
-    }
+  public List<FeedProjection> fetchByUserNo(Long userNo, Long lastFeedNo, int pageSize) {
+    return factory.from(feed)
+        .select(
+            Projections.constructor(FeedProjection.class, feed.feedNo, feed.postNo, feed.writerId,
+                feed.writerNickname, feed.content, feed.likeCount, feed.writeDateTime,
+                Expressions.as(
+                    JPAExpressions.select(
+                            Expressions.stringTemplate("group_concat({0})", postImage.filePath))
+                        .from(postImage)
+                        .where(postImage.post.postNo.eq(feed.postNo))
+                        .groupBy(postImage.post.postNo),
+                    "imagePaths"),
+                Expressions.as(
+                    JPAExpressions.select(
+                            Expressions.stringTemplate("group_concat({0})", tag.content))
+                        .from(tag)
+                        .join(postTag)
+                        .on(tag.tagNo.eq(postTag.tag.tagNo))
+                        .where(postTag.post.postNo.eq(feed.postNo))
+                        .groupBy(postTag.post.postNo), "tags")
+            ))
+        .where(feed.feedUserNo.eq(userNo), lowerThan(lastFeedNo))
+        .limit(pageSize)
+        .orderBy(feed.feedNo.desc())
+        .fetch();
+  }
 
-    private BooleanExpression lowerThan(Long feedNo) {
-        return feedNo != null ? feed.feedNo.lt(feedNo) : null;
-    }
+  private BooleanExpression lowerThan(Long feedNo) {
+    return feedNo != null ? feed.feedNo.lt(feedNo) : null;
+  }
 }

--- a/src/main/java/kr/co/writenow/writenow/repository/feed/FeedRepositoryCustom.java
+++ b/src/main/java/kr/co/writenow/writenow/repository/feed/FeedRepositoryCustom.java
@@ -1,17 +1,11 @@
 package kr.co.writenow.writenow.repository.feed;
 
 import static kr.co.writenow.writenow.domain.feed.QFeed.feed;
-import static kr.co.writenow.writenow.domain.post.QPostImage.postImage;
-import static kr.co.writenow.writenow.domain.post.QPostTag.postTag;
-import static kr.co.writenow.writenow.domain.tag.QTag.tag;
 
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
-import kr.co.writenow.writenow.repository.post.projection.FeedProjection;
+import kr.co.writenow.writenow.domain.feed.Feed;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -21,27 +15,8 @@ public class FeedRepositoryCustom {
 
   private final JPAQueryFactory factory;
 
-  public List<FeedProjection> fetchByUserNo(Long userNo, Long lastFeedNo, int pageSize) {
-    return factory.from(feed)
-        .select(
-            Projections.constructor(FeedProjection.class, feed.feedNo, feed.postNo, feed.writerId,
-                feed.writerNickname, feed.content, feed.likeCount, feed.writeDateTime,
-                Expressions.as(
-                    JPAExpressions.select(
-                            Expressions.stringTemplate("group_concat({0})", postImage.filePath))
-                        .from(postImage)
-                        .where(postImage.post.postNo.eq(feed.postNo))
-                        .groupBy(postImage.post.postNo),
-                    "imagePaths"),
-                Expressions.as(
-                    JPAExpressions.select(
-                            Expressions.stringTemplate("group_concat({0})", tag.content))
-                        .from(tag)
-                        .join(postTag)
-                        .on(tag.tagNo.eq(postTag.tag.tagNo))
-                        .where(postTag.post.postNo.eq(feed.postNo))
-                        .groupBy(postTag.post.postNo), "tags")
-            ))
+  public List<Feed> fetchByUserNo(Long userNo, Long lastFeedNo, int pageSize) {
+    return factory.selectFrom(feed)
         .where(feed.feedUserNo.eq(userNo), lowerThan(lastFeedNo))
         .limit(pageSize)
         .orderBy(feed.feedNo.desc())

--- a/src/main/java/kr/co/writenow/writenow/repository/post/projection/FeedProjection.java
+++ b/src/main/java/kr/co/writenow/writenow/repository/post/projection/FeedProjection.java
@@ -1,9 +1,9 @@
 package kr.co.writenow.writenow.repository.post.projection;
 
-import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import kr.co.writenow.writenow.common.DateUtil;
+import java.util.stream.Collectors;
 import lombok.Getter;
 
 @Getter
@@ -20,7 +20,7 @@ public class FeedProjection {
     private Set<String> tags;
 
     public FeedProjection(Long feedNo, Long postNo, String writerId, String writerNickname, String content,
-        int likeCount, String writeDateTime) {
+        int likeCount, String writeDateTime, String imagePaths, String tags) {
         this.feedNo = feedNo;
         this.postNo = postNo;
         this.userId = writerId;
@@ -28,6 +28,12 @@ public class FeedProjection {
         this.content = content;
         this.likeCount = likeCount;
         this.writeDateTime = writeDateTime;
+        if(imagePaths != null){
+            this.imagePaths = Arrays.stream(imagePaths.split(",")).toList();
+        }
+        if(tags != null){
+            this.tags = Arrays.stream(tags.split(",")).collect(Collectors.toSet());
+        }
     }
 
 }

--- a/src/main/java/kr/co/writenow/writenow/repository/post/projection/FeedProjection.java
+++ b/src/main/java/kr/co/writenow/writenow/repository/post/projection/FeedProjection.java
@@ -9,27 +9,25 @@ import lombok.Getter;
 @Getter
 public class FeedProjection {
 
-  private Long postNo;
-  private String userId;
-  private String userNickname;
-  private String content;
-  private Integer likeCount;
-  private String writeDateTime;
-  private List<String> imagePaths;
-  private Set<String> tags;
+    private Long feedNo;
+    private Long postNo;
+    private String userId;
+    private String userNickname;
+    private String content;
+    private Integer likeCount;
+    private String writeDateTime;
+    private List<String> imagePaths;
+    private Set<String> tags;
 
+    public FeedProjection(Long feedNo, Long postNo, String writerId, String writerNickname, String content,
+        int likeCount, String writeDateTime) {
+        this.feedNo = feedNo;
+        this.postNo = postNo;
+        this.userId = writerId;
+        this.userNickname = writerNickname;
+        this.content = content;
+        this.likeCount = likeCount;
+        this.writeDateTime = writeDateTime;
+    }
 
-  public FeedProjection(Long postNo, String userId, String userNickname, String content, Integer likeCount,
-      LocalDateTime writeDateTime, List<String> imagePaths, Set<String> tags) {
-    this.postNo = postNo;
-    this.userId = userId;
-    this.userNickname = userNickname;
-    this.content = content;
-    this.likeCount = likeCount;
-    DateUtil.datetimeConvertToString(writeDateTime).ifPresent(datetime-> {
-      this.writeDateTime = datetime;
-    });
-    this.imagePaths = imagePaths;
-    this.tags = tags;
-  }
 }

--- a/src/main/java/kr/co/writenow/writenow/service/feed/FeedService.java
+++ b/src/main/java/kr/co/writenow/writenow/service/feed/FeedService.java
@@ -9,6 +9,7 @@ import kr.co.writenow.writenow.domain.user.User;
 import kr.co.writenow.writenow.repository.feed.FeedRepository;
 import kr.co.writenow.writenow.repository.user.FollowRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,7 @@ public class FeedService {
   private final FeedRepository feedRepository;
   private final FollowRepository followRepository;
 
+  @Async
   public void save(Post post, User writer){
     //1. 글쓴이를 팔로우 하고 있는 전체 유저 조회
     List<Follow> follows = followRepository.findByFollowee(writer);

--- a/src/main/java/kr/co/writenow/writenow/service/feed/FeedService.java
+++ b/src/main/java/kr/co/writenow/writenow/service/feed/FeedService.java
@@ -2,14 +2,16 @@ package kr.co.writenow.writenow.service.feed;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import kr.co.writenow.writenow.domain.feed.Feed;
 import kr.co.writenow.writenow.domain.post.Post;
 import kr.co.writenow.writenow.domain.user.Follow;
 import kr.co.writenow.writenow.domain.user.User;
 import kr.co.writenow.writenow.repository.feed.FeedRepository;
+import kr.co.writenow.writenow.repository.post.PostRepository;
 import kr.co.writenow.writenow.repository.user.FollowRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.jms.annotation.JmsListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,23 +22,28 @@ public class FeedService {
 
   private final FeedRepository feedRepository;
   private final FollowRepository followRepository;
+  private final PostRepository postRepository;
 
-  @Async
-  public void save(Post post, User writer){
-    //1. 글쓴이를 팔로우 하고 있는 전체 유저 조회
-    List<Follow> follows = followRepository.findByFollowee(writer);
-    List<Feed> feeds = new ArrayList<>();
+  @JmsListener(destination = "post", containerFactory = "myFactory")
+  public void save(Long postNo){
+    Optional<Post> maybePost = postRepository.findById(postNo);
+    maybePost.ifPresent(post-> {
+      User writer = post.getWriter();
+      //1. 글쓴이를 팔로우 하고 있는 전체 유저 조회
+      List<Follow> follows = followRepository.findByFollowee(writer);
+      List<Feed> feeds = new ArrayList<>();
 
-    //2. 팔로우 하고 있는 유저의 피드를 생성
-    for (Follow follow : follows) {
-      Feed feed = new Feed(follow.getFollower().getUserNo(), post, writer);
-      feeds.add(feed);
-    }
+      //2. 팔로우 하고 있는 유저의 피드를 생성
+      for (Follow follow : follows) {
+        Feed feed = new Feed(follow.getFollower().getUserNo(), post, writer);
+        feeds.add(feed);
+      }
 
-    // 3. 내 피드에 나와야 하니까 추가
-    feeds.add(new Feed(writer.getUserNo(), post, writer));
+      // 3. 내 피드에 나와야 하니까 추가
+      feeds.add(new Feed(writer.getUserNo(), post, writer));
 
-    feedRepository.saveAll(feeds);
+      feedRepository.saveAll(feeds);
+    });
   }
 
 }

--- a/src/main/java/kr/co/writenow/writenow/service/post/PostService.java
+++ b/src/main/java/kr/co/writenow/writenow/service/post/PostService.java
@@ -59,6 +59,7 @@ public class PostService {
 
         // 글 작성 이벤트 날리기
         jmsTemplate.convertAndSend("post", post.getPostNo());
+
         //feedService.save(post);
 
         return new PostResponse(post);

--- a/src/main/java/kr/co/writenow/writenow/service/post/PostService.java
+++ b/src/main/java/kr/co/writenow/writenow/service/post/PostService.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ObjectUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -39,22 +40,23 @@ public class PostService {
     private static final String S3_POST_DIR = "post";
 
     public PostResponse writePost(@Valid PostWriteRequest request, String userId) {
-        // 1. 글 저장
+        // 글 저장
         User user = userService.fetchUserByUserId(userId);
         Post post = new Post(user, request.getContent(), request.getCategoryCode());
         post = postRepository.save(post);
 
-        List<File> files = makeFiles(request.getFiles());
-        String customFilePath = String.join("/", S3_POST_DIR, String.valueOf(post.getPostNo()));
+        // 파일 업로드
+        if (!ObjectUtils.isEmpty(request.getFiles())) {
+            List<File> files = makeFiles(request.getFiles());
+            String customFilePath = String.join("/", S3_POST_DIR, String.valueOf(post.getPostNo()));
+            post.addPostImages(postImageService.makePostImageList(post, files, customFilePath));
+            fileService.upload(files, customFilePath);
+        }
 
-        //2. 글의 태그, 이미지 저장
+        //글의 태그, 이미지 저장
         post.addPostTags(postTagService.makePostTagSet(post, request.getTagValues()));
-        post.addPostImages(postImageService.makePostImageList(post, files, customFilePath));
 
-        //3. 파일 업로드
-        fileService.upload(files, customFilePath);
-
-        //4. 피드 생성
+        // 피드 생성
         feedService.save(post, user);
 
         return new PostResponse(post);

--- a/src/main/java/kr/co/writenow/writenow/service/post/PostService.java
+++ b/src/main/java/kr/co/writenow/writenow/service/post/PostService.java
@@ -10,7 +10,6 @@ import kr.co.writenow.writenow.common.file.FileUtil;
 import kr.co.writenow.writenow.domain.post.Post;
 import kr.co.writenow.writenow.domain.user.User;
 import kr.co.writenow.writenow.repository.post.PostRepository;
-import kr.co.writenow.writenow.service.feed.FeedService;
 import kr.co.writenow.writenow.service.post.dto.PostResponse;
 import kr.co.writenow.writenow.service.post.dto.PostWriteRequest;
 import kr.co.writenow.writenow.service.user.UserService;
@@ -36,7 +35,6 @@ public class PostService {
     private final FileUtil fileUtil;
     private final FileService fileService;
     private final UserService userService;
-    private final FeedService feedService;
     private final JmsTemplate jmsTemplate;
     private static final String S3_POST_DIR = "post";
 
@@ -59,8 +57,6 @@ public class PostService {
 
         // 글 작성 이벤트 날리기
         jmsTemplate.convertAndSend("post", post.getPostNo());
-
-        //feedService.save(post);
 
         return new PostResponse(post);
     }

--- a/src/main/java/kr/co/writenow/writenow/service/user/UserService.java
+++ b/src/main/java/kr/co/writenow/writenow/service/user/UserService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import kr.co.writenow.writenow.config.security.jwt.JwtTokenProvider;
+import kr.co.writenow.writenow.domain.feed.Feed;
 import kr.co.writenow.writenow.domain.user.Follow;
 import kr.co.writenow.writenow.domain.user.Role;
 import kr.co.writenow.writenow.domain.user.User;
@@ -13,6 +14,8 @@ import kr.co.writenow.writenow.exception.CustomException;
 import kr.co.writenow.writenow.exception.user.InvalidUserException;
 import kr.co.writenow.writenow.exception.user.UserNotFoundException;
 import kr.co.writenow.writenow.exception.user.UserRegisterException;
+import kr.co.writenow.writenow.repository.feed.FeedRepository;
+import kr.co.writenow.writenow.repository.feed.FeedRepositoryCustom;
 import kr.co.writenow.writenow.repository.post.PostRepositoryCustom;
 import kr.co.writenow.writenow.repository.post.projection.FeedProjection;
 import kr.co.writenow.writenow.repository.user.FollowRepository;
@@ -51,6 +54,7 @@ public class UserService {
   private final JwtTokenProvider tokenProvider;
   private final FollowRepository followRepository;
   private final PostRepositoryCustom postRepositoryCustom;
+  private final FeedRepositoryCustom feedRepositoryCustom;
 
   /**
    * @param request email, nickname, userId, password, gender
@@ -167,9 +171,10 @@ public class UserService {
     followRepository.deleteByFollowerAndFollowee(follower, followee);
   }
 
-  public List<FeedResponse> fetchFeed(Long lastPostNo, String userId, Pageable pageable) {
-    List<FeedProjection> queryResults = postRepositoryCustom.fetchFeed(lastPostNo, userId,
-        pageable);
-    return queryResults.stream().map(FeedResponse::new).collect(Collectors.toList());
+  public List<FeedResponse> fetchFeed(Long lastFeedNo, String userId, Pageable pageable) {
+    User user = fetchUserByUserId(userId);
+    List<FeedProjection> queryResults = feedRepositoryCustom
+        .fetchByUserNo(user.getUserNo(), lastFeedNo, pageable.getPageSize());
+    return queryResults.stream().map(FeedResponse::new).toList();
   }
 }

--- a/src/main/java/kr/co/writenow/writenow/service/user/UserService.java
+++ b/src/main/java/kr/co/writenow/writenow/service/user/UserService.java
@@ -2,7 +2,6 @@ package kr.co.writenow.writenow.service.user;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import kr.co.writenow.writenow.config.security.jwt.JwtTokenProvider;
 import kr.co.writenow.writenow.domain.user.Follow;
@@ -13,10 +12,8 @@ import kr.co.writenow.writenow.exception.user.InvalidUserException;
 import kr.co.writenow.writenow.exception.user.UserNotFoundException;
 import kr.co.writenow.writenow.exception.user.UserRegisterException;
 import kr.co.writenow.writenow.repository.feed.FeedRepositoryCustom;
-import kr.co.writenow.writenow.repository.post.projection.FeedProjection;
 import kr.co.writenow.writenow.repository.user.FollowRepository;
 import kr.co.writenow.writenow.repository.user.UserRepository;
-import kr.co.writenow.writenow.service.user.dto.FeedResponse;
 import kr.co.writenow.writenow.service.user.dto.FollowRequest;
 import kr.co.writenow.writenow.service.user.dto.FollowResponse;
 import kr.co.writenow.writenow.service.user.dto.LoginRequest;
@@ -24,7 +21,6 @@ import kr.co.writenow.writenow.service.user.dto.LoginResponse;
 import kr.co.writenow.writenow.service.user.dto.RegisterRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -166,10 +162,4 @@ public class UserService {
     followRepository.deleteByFollowerAndFollowee(follower, followee);
   }
 
-  public List<FeedResponse> fetchFeed(Long lastFeedNo, String userId, Pageable pageable) {
-    User user = fetchUserByUserId(userId);
-    List<FeedProjection> queryResults = feedRepositoryCustom
-        .fetchByUserNo(user.getUserNo(), lastFeedNo, pageable.getPageSize());
-    return queryResults.stream().map(FeedResponse::new).toList();
-  }
 }

--- a/src/main/java/kr/co/writenow/writenow/service/user/UserService.java
+++ b/src/main/java/kr/co/writenow/writenow/service/user/UserService.java
@@ -4,9 +4,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import kr.co.writenow.writenow.config.security.jwt.JwtTokenProvider;
-import kr.co.writenow.writenow.domain.feed.Feed;
 import kr.co.writenow.writenow.domain.user.Follow;
 import kr.co.writenow.writenow.domain.user.Role;
 import kr.co.writenow.writenow.domain.user.User;
@@ -14,9 +12,7 @@ import kr.co.writenow.writenow.exception.CustomException;
 import kr.co.writenow.writenow.exception.user.InvalidUserException;
 import kr.co.writenow.writenow.exception.user.UserNotFoundException;
 import kr.co.writenow.writenow.exception.user.UserRegisterException;
-import kr.co.writenow.writenow.repository.feed.FeedRepository;
 import kr.co.writenow.writenow.repository.feed.FeedRepositoryCustom;
-import kr.co.writenow.writenow.repository.post.PostRepositoryCustom;
 import kr.co.writenow.writenow.repository.post.projection.FeedProjection;
 import kr.co.writenow.writenow.repository.user.FollowRepository;
 import kr.co.writenow.writenow.repository.user.UserRepository;
@@ -53,7 +49,6 @@ public class UserService {
   private final AuthenticationManager authenticationManager;
   private final JwtTokenProvider tokenProvider;
   private final FollowRepository followRepository;
-  private final PostRepositoryCustom postRepositoryCustom;
   private final FeedRepositoryCustom feedRepositoryCustom;
 
   /**

--- a/src/main/java/kr/co/writenow/writenow/service/user/dto/FeedResponse.java
+++ b/src/main/java/kr/co/writenow/writenow/service/user/dto/FeedResponse.java
@@ -2,8 +2,12 @@ package kr.co.writenow.writenow.service.user.dto;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import kr.co.writenow.writenow.common.DateUtil;
 import kr.co.writenow.writenow.domain.feed.Feed;
-import kr.co.writenow.writenow.repository.post.projection.FeedProjection;
+import kr.co.writenow.writenow.domain.post.Post;
+import kr.co.writenow.writenow.domain.post.PostImage;
+import kr.co.writenow.writenow.domain.user.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -22,14 +26,23 @@ public class FeedResponse {
   private List<String> imagePath;
   private Set<String> tags;
 
-  public FeedResponse(FeedProjection projection) {
-    this.feedNo = projection.getFeedNo();
-    this.userId = projection.getUserId();
-    this.userNickname = projection.getUserNickname();
-    this.content = projection.getContent();
-    this.likeCount = projection.getLikeCount();
-    this.writeDateTime = projection.getWriteDateTime();
-    this.imagePath = projection.getImagePaths();
-    this.tags = projection.getTags();
+  public FeedResponse(Feed feed) {
+    Post post = feed.getPost();
+    User writer = post.getWriter();
+    this.feedNo = feed.getFeedNo();
+    this.userId = writer.getUserId();
+    this.userNickname = writer.getNickname();
+    this.content = post.getContent();
+    this.likeCount = post.getLikeCount();
+    DateUtil.datetimeConvertToString(post.getCreatedDatetime()).ifPresent(datetime -> {
+      this.writeDateTime = datetime;
+    });
+
+    this.imagePath = post.getPostImages().stream()
+        .map(PostImage::getFilePath)
+        .collect(Collectors.toList());
+    this.tags = post.getTags().stream()
+        .map(it-> it.getTag().getContent())
+        .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/kr/co/writenow/writenow/service/user/dto/FeedResponse.java
+++ b/src/main/java/kr/co/writenow/writenow/service/user/dto/FeedResponse.java
@@ -2,6 +2,7 @@ package kr.co.writenow.writenow.service.user.dto;
 
 import java.util.List;
 import java.util.Set;
+import kr.co.writenow.writenow.domain.feed.Feed;
 import kr.co.writenow.writenow.repository.post.projection.FeedProjection;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class FeedResponse {
 
-  private Long postNo;
+  private Long feedNo;
   private String userId;
   private String userNickname;
   private String content;
@@ -22,7 +23,7 @@ public class FeedResponse {
   private Set<String> tags;
 
   public FeedResponse(FeedProjection projection) {
-    this.postNo = projection.getPostNo();
+    this.feedNo = projection.getFeedNo();
     this.userId = projection.getUserId();
     this.userNickname = projection.getUserNickname();
     this.content = projection.getContent();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,10 @@ server:
     threads:
       min-spare: 30
 
+threadPool:
+  core-size: 70
+  max-size: 200
+  queue-size: 100
 
 spring:
   datasource:


### PR DESCRIPTION
## 요약
- 글 작성 시 피드를 발행하는 로직을 비동기로 처리하게끔 변경

## 주요 변경사항
- 비동기 처리를 할 수 있게끔 spring 설정 추가
- 피드 발행 로직을 @Async를 추가해 비동기로 처리

## 리뷰 필요부분

- ThreadPool의 설정 값을(ex. 코어 갯수) 설정하는데 있어 서버 CPU의 성능에 따라 다르게 할당해야 한다고 알고 있습니다. 그런데 예를들어 로컬 환경과 운영 환경의 성능이 차이가 있을 때 값을 환경에 따라 다르게 처리할 수 있어야할텐데, 이를 yml의 변수로 지정해 관리를 해야하는 것인지 실무적으로 어떻게 처리하는게 좋을 지 알고 싶습니다.
- 동기 처리에서는 반환 값이 void여도 로직에서 예외가 발생했다면 즉시 알 수 있는데 비동기 처리에서는 다른 스레드에서 수행되므로 void일 때 예외를 잡아내기 어려울 것 같습니다. 즉 리턴이 void인 경우 비동기 로직을 어떻게 처리하면 좋을까요?